### PR TITLE
Fix bug in hazard combination script

### DIFF
--- a/scripts/3.1-combine-rainfall-hand-hazard.py
+++ b/scripts/3.1-combine-rainfall-hand-hazard.py
@@ -33,5 +33,4 @@ def main():
 
     combined_df.to_csv(output_csv, index=False)
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    main()

--- a/scripts/4.2-compute-heatwave-days.py
+++ b/scripts/4.2-compute-heatwave-days.py
@@ -107,5 +107,4 @@ def main():
 
 
 # In[ ]:
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    main()

--- a/scripts/99-combine-hazards.py
+++ b/scripts/99-combine-hazards.py
@@ -41,11 +41,11 @@ def main():
     )
     
     hazard_df = hazard_df.rename(columns={
-    'rainfall_hazard': 'rain_h',
-    'hand_hazard': 'hand_h',
-    'combined_fflood_hazard': 'flood_h',
-    'heat_hazard': 'heat_h',
-    'total_hazard': 'total_h'
+        'rainfall_hazard': 'rain_h',
+        'hand_hazard': 'hand_h',
+        'combined_flood_hazard': 'flood_h',
+        'heat_hazard': 'heat_h',
+        'total_hazard': 'total_h'
     })
 
 


### PR DESCRIPTION
## Summary
- fix column rename typo when combining hazard tables
- add newline terminators to several scripts for cleanliness

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686d87e0cf348323b06d731da6c601d1