### PR TITLE
Fix folder block markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ climate-hazard/
 │   ├── aoi/                # Bangladesh district shapefiles (user AOI goes here)
 │   └──  interim/           # Intermediate data
 │         ├── hand/         # Downloaded and processed hand data
-│         ├── heat/     ``` # Downloaded and processed heat data
-│         └── febdem/       # Downloaded and processed DEM tiles
+│         ├── heat/         # Downloaded and processed heat data
+│         └── fabdem/       # Downloaded and processed DEM tiles
 ├── scripts/                # All pipeline Python scripts
 ├── results/                # Output CSVs, shapefiles, hazard maps
 ├── main.py                 # Pipeline runner


### PR DESCRIPTION
## Summary
- correct the README folder block by removing stray backticks
- rename `febdem` to `fabdem`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d89a2d6848323aa0960b59c330d7e