### PR TITLE
Move imports to top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Each score (rainfall, flood, heat, etc.) is normalised (min-max or percentile) a
 
 ## Project Overview
 
-- Fully automated, script-based workflow (run with `python main.py`)
+- Fully automated, script-based workflow (run with `python main.py`).
+  Each script imports its dependencies at the top level so they can be
+  executed individually or through the runner using `runpy`.
 - Download and process:
   - **ERA5 Rainfall** (monthly means, 2020–2024)
   - **ESA FABDEM DEM** (for HAND/flood risk)
@@ -93,7 +95,7 @@ Run the entire pipeline with:
 python main.py
 ```
 
-This will execute all scripts in order and generate results in `/results`.
+This will execute all scripts in order using `runpy` and generate results in `/results`.
 
 Or run scripts individually, e.g.:
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import subprocess
+import runpy
 
 scripts = [
     "scripts/1.2-compute-heavy-rain-months.py",
@@ -12,6 +12,6 @@ scripts = [
 
 for script in scripts:
     print(f"\n=== Running: {script} ===")
-    subprocess.run(["python", script], check=True)
+    runpy.run_path(script, run_name="__main__")
 
 print("\n✅ All steps complete!")

--- a/scripts/1.1-download-era5.py
+++ b/scripts/1.1-download-era5.py
@@ -1,8 +1,8 @@
+import os
+import geopandas as gpd
+import cdsapi
+
 def main():
-    
-    import os
-    import geopandas as gpd
-    import cdsapi
 
 
     # AOI shapefile path

--- a/scripts/1.2-compute-heavy-rain-months.py
+++ b/scripts/1.2-compute-heavy-rain-months.py
@@ -1,14 +1,14 @@
-def main():
+import os
+import xarray as xr
+import rioxarray
+import geopandas as gpd
+import rasterio
+import rasterio.mask
+import pandas as pd
+import numpy as np
+from tqdm import tqdm
 
-    import os
-    import xarray as xr
-    import rioxarray
-    import geopandas as gpd
-    import rasterio
-    import rasterio.mask
-    import pandas as pd
-    import numpy as np
-    from tqdm import tqdm
+def main():
 
     # # Define Paths
 

--- a/scripts/2.1-download-fabdem-tiles.py
+++ b/scripts/2.1-download-fabdem-tiles.py
@@ -1,10 +1,10 @@
+import os
+import geopandas as gpd
+import requests
+import zipfile
+from tqdm import tqdm
+
 def main():
-    
-    import os
-    import geopandas as gpd
-    import requests
-    import zipfile
-    from tqdm import tqdm
 
     # # Define Paths
 

--- a/scripts/2.2-create-hand.py
+++ b/scripts/2.2-create-hand.py
@@ -1,16 +1,16 @@
-def main():
+import shutil
+import os
+import glob
+import geopandas as gpd
+import rasterio
+from rasterio.merge import merge
+from rasterio.mask import mask
+from rasterio.warp import calculate_default_transform, reproject, Resampling
+import numpy as np
+import matplotlib.pyplot as plt
+from tqdm import tqdm
 
-    import shutil
-    import os
-    import glob
-    import geopandas as gpd
-    import rasterio
-    from rasterio.merge import merge
-    from rasterio.mask import mask
-    from rasterio.warp import calculate_default_transform, reproject, Resampling
-    import numpy as np
-    import matplotlib.pyplot as plt
-    from tqdm import tqdm
+def main():
 
 
 

--- a/scripts/2.3-compute-hand.py
+++ b/scripts/2.3-compute-hand.py
@@ -1,9 +1,9 @@
+import os
+from whitebox.whitebox_tools import WhiteboxTools
+import rasterio
+import matplotlib.pyplot as plt
+
 def main():
-    
-    import os
-    from whitebox.whitebox_tools import WhiteboxTools
-    import rasterio
-    import matplotlib.pyplot as plt
 
     # # Define Paths
 

--- a/scripts/2.4-classify-flood-prone.py
+++ b/scripts/2.4-classify-flood-prone.py
@@ -1,19 +1,15 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import numpy as np
+import rasterio
+import rioxarray
+import geopandas as gpd
+import pandas as pd
+import matplotlib.pyplot as plt
+
 def main():
-    #!/usr/bin/env python
-    # coding: utf-8
-
-    # # Import Libraries
-
-    # In[2]:
-
-
-    import os
-    import numpy as np
-    import rasterio
-    import rioxarray
-    import geopandas as gpd
-    import pandas as pd
-    import matplotlib.pyplot as plt
 
 
 

--- a/scripts/3.1-combine-rainfall-hand-hazard.py
+++ b/scripts/3.1-combine-rainfall-hand-hazard.py
@@ -1,7 +1,8 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+
 def main():
-    import pandas as pd
-    import matplotlib.pyplot as plt
-    import os
 
     # # Define Paths
 

--- a/scripts/4.1-download-era5-data.py
+++ b/scripts/4.1-download-era5-data.py
@@ -1,20 +1,16 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import cdsapi
+import xarray as xr
+import rioxarray
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import os
+
 def main():
-    #!/usr/bin/env python
-    # coding: utf-8
-
-    # # Import Libraries
-
-    # In[1]:
-
-
-    import cdsapi
-    import xarray as xr
-    import rioxarray
-    import geopandas as gpd
-    import matplotlib.pyplot as plt
-    import pandas as pd
-    import numpy as np
-    import os
 
 
 

--- a/scripts/4.2-compute-heatwave-days.py
+++ b/scripts/4.2-compute-heatwave-days.py
@@ -1,13 +1,13 @@
+import os
+import xarray as xr
+import geopandas as gpd
+import rasterio
+import rasterio.mask
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
 def main():
-    
-    import os
-    import xarray as xr
-    import geopandas as gpd
-    import rasterio
-    import rasterio.mask
-    import numpy as np
-    import pandas as pd
-    from tqdm import tqdm
 
 
 

--- a/scripts/99-combine-hazards.py
+++ b/scripts/99-combine-hazards.py
@@ -1,8 +1,8 @@
-def main():
+import pandas as pd
+import geopandas as gpd
+import os
 
-    import pandas as pd
-    import geopandas as gpd
-    import os
+def main():
 
 
 


### PR DESCRIPTION
## Summary
- move imports to the top of all scripts
- run scripts from `main.py` using `runpy`
- update README to note new runner behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d8d0fc21883238dcbaffdb92cd9d9